### PR TITLE
Show elapsed time for lint tasks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ if (process.stdout.isTTY) {
                 debug(committedGitFiles);
                 new Listr(resolveMainTask({ tasks, committedGitFiles }), {
                   exitOnError: false,
-                  concurrent: true
+                  concurrent: true,
+                  collapse: false
                 })
                   .run()
                   .then(() => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "node_modules/.bin/eslint *.js",
+    "lint": "node_modules/.bin/eslint **/*.js",
     "format": "yarn lint --fix",
     "prepush": "node index.js"
   },

--- a/utils/resolveLintTask.js
+++ b/utils/resolveLintTask.js
@@ -3,9 +3,11 @@ const execTask = require("./execTask");
 module.exports = function resolveLintTask(commandList, fileList) {
   return commandList.map(command => ({
     title: command,
-    task: execTask({
+    task: (ctx, task) => execTask({
       command,
-      fileList
-    })
+      fileList,
+      ctx,
+      task
+    })()
   }));
 };


### PR DESCRIPTION
<img width="465" alt="Screen Shot 2019-05-09 at 12 50 02" src="https://user-images.githubusercontent.com/7725225/57435347-c8067400-725a-11e9-8b9b-49ea77d5c5a2.png">

I tried making this configurable but it looks like there will be too many changes involved due to loading the config in the execTask util. I am therefore staying away from it for now.

I have also added screenshots to `.npmignore` to reduce the download size on `npm i`.