### PR TITLE
feat: use currentBranch for diff if it has already been pushed to remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,30 +56,71 @@ if (process.stdout.isTTY) {
                 return;
               }
 
-              // Fetching committed git files
-              fetchGitDiff( baseBranch ).then((committedGitFiles = []) => {
-                debug(committedGitFiles);
-                new Listr(resolveMainTask({ tasks, committedGitFiles }), {
-                  exitOnError: false,
-                  concurrent: true,
-                  collapse: false
-                })
-                  .run()
-                  .then(() => {
-                    cache.setSync("linted-hash", commitHash);
-                    debug('Cached Current Commit Hash');
-                    log(success("\nVoila! 🎉  Code is ready to be Shipped.\n"));
-                  })
-                  .catch(({ errors }) => {
-                    process.exitCode = 1;
-                    errors.forEach(err => {
-                      console.error(err.customErrorMessage);
+              // see if the branch exists on the remote
+              // adapted from:  https://stackoverflow.com/a/44401325/656011
+              const isCurrentBranchPublished = `git ls-remote --exit-code --heads $(git remote | head -1) "${currentBranch}"`;
+
+              let resolveBranch = Promise.resolve(baseBranch);
+
+              // we're going to use the success/error of the call to isCurrentBranchPublished
+              // so we'll return the correct branch based on the exit code we receive
+              const getDiffBranch = execChildProcess({ command: isCurrentBranchPublished })
+                .then(() => {
+                  const getRemote = 'git remote | head -1';
+
+                  // if the current branch has been pushed to the remote
+                  // we'll compare to the currentBranch for our diff
+                  return execChildProcess({ command: getRemote })
+                    .then((remote) => {
+                      const branch = `${remote}/${currentBranch}`;
+                      debug('Branch to Diff:' + branch);
+                      return branch;
+                    })
+                    .catch(() => {
+                      debug('Branch to Diff:' + baseBranch);
+
+                      // if we can't find the remote, we'll fall back to the baseBranch
+                      return baseBranch;
                     });
-                  });
+                })
+                .catch(() => {
+                  debug('Branch to Diff:' + baseBranch);
+
+                  return resolveBranch;
+                });
+
+              // now that we have the branch we need to diff against, let's diff
+              getDiffBranch.then((diffBranch) => {
+                // Fetching committed git files
+                fetchGitDiff( diffBranch ).then((committedGitFiles = []) => {
+                  debug(committedGitFiles);
+                  new Listr(resolveMainTask({ tasks, committedGitFiles }), {
+                    exitOnError: false,
+                    concurrent: true,
+                    collapse: false
+                  })
+                    .run()
+                    .then(() => {
+                      cache.setSync("linted-hash", commitHash);
+                      debug('Cached Current Commit Hash');
+                      log(success("\nVoila! 🎉  Code is ready to be Shipped.\n"));
+                    })
+                    .catch(({ errors }) => {
+                      process.exitCode = 1;
+                      errors.forEach(err => {
+                        console.error(err.customErrorMessage);
+                      });
+                    });
+                })
+                .catch((message = '') => {
+                  process.exitCode = 1;
+                  log(warning(message));
+                });
               })
-              .catch((message = '') => {
+              .catch((e) => {
+                log(error(e));
                 process.exitCode = 1;
-                log(warning(message));
+                return;
               });
             });
         })

--- a/utils/fetchGitDiff.js
+++ b/utils/fetchGitDiff.js
@@ -3,7 +3,7 @@ const { execChildProcess } = require("./common");
 module.exports = function fetchGitDiff( baseBranch = "master" ) {
 
   // git command to pull out the changed file names between current branch and base branch (Excluded delelted files which cannot be fetched now)
-  let command = `git diff --relative --name-only --diff-filter=d ${baseBranch}...HEAD`;
+  let command = `git diff --relative --name-only --diff-filter=d ${baseBranch}`;
 
   return new Promise( (resolve, reject) => {
     return execChildProcess({ command })


### PR DESCRIPTION
This PR introduces a check to see if the `currentBranch` has already been pushed to the remote. If it has, we will use it for the `diff` instead of the `baseBranch`.

Closes #26 