### PR TITLE
feat: lint against remote baseBranch if user is on baseBranch

### DIFF
--- a/utils/fetchGitDiff.js
+++ b/utils/fetchGitDiff.js
@@ -2,8 +2,9 @@ const { execChildProcess } = require("./common");
 
 module.exports = function fetchGitDiff( baseBranch = "master" ) {
 
-  // git command to pull out the changed file names between current branch and base branch (Excluded delelted files which cannot be fetched now)
-  let command = `git diff --relative --name-only --diff-filter=d ${baseBranch}...HEAD`;
+  // git command to pull out the changed file names between current branch and base branch
+  // (Excluded deleted files which cannot be fetched now)
+  let command = `git diff --relative --name-only --diff-filter=d ${baseBranch}`;
 
   return new Promise( (resolve, reject) => {
     return execChildProcess({ command })


### PR DESCRIPTION
I wasn't sure how you'd want to approach this, but here's a PR that implements opting into linting of the base branch so that no one already using this has to adjust their workflow at all.

Let me know if you have a different vision for the approach and I'd be happy to adjust the PR to reflect that.

Closes #13 