### PR TITLE
Feature/change chalk colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lint-prepush    
+# lint-prepush
 [![npm version](https://badge.fury.io/js/lint-prepush.svg)](https://www.npmjs.com/package/lint-prepush)
 [![npm downloads](https://img.shields.io/npm/dt/lint-prepush.svg)](https://www.npmtrends.com/lint-prepush)
 [![GitHub license](https://img.shields.io/github/license/theenadayalank/lint-prepush.svg)](https://github.com/theenadayalank/lint-prepush/blob/master/LICENSE)
@@ -31,7 +31,7 @@ It require Node.js v6 or newer. It also requires a package to manage git hooks. 
 
 ### Installing
 
-* This project requires a package to manage git hooks depending. 
+* This project requires a package to manage git hooks depending.
 * I strongly suggest [Husky](https://github.com/typicode/husky) which pauses the git push by overriding pre-commit hook (it almost overrides all hooks, here we need only pre-push hook) and allow us to run our custom scripts and resumes pushing.
 
 
@@ -67,6 +67,47 @@ Configure the following scripts in package.json to lint your committed files ðŸ”
 }
 ```
 
+### Output Colors
+
+In case the default output colors don't render well in your terminal, you can adjust them
+by adding a `theme` configuration Object to the `lint-prepush` configuration.
+
+You can use any of the default `keyword`s available in [`chalk`](https://github.com/chalk/chalk),
+and you can override a one, two, or all three of the colors.
+
+The default theme is:
+
+```json
+{
+  "theme": {
+    "success": "green",
+    "error": "red",
+    "warning": "orange"
+  }
+}
+```
+
+```diff
+{
+  "scripts": {
+    "prepush": "lint-prepush"
+  },
+  "lint-prepush": {
+    "base": "master",
+    "tasks": {
+      "*.js": [
+        "eslint"
+      ]
++    },
++    "theme": {
++       "warning": "gray",
++       "error": "orange",
++       "success": "blue"
++    }
+  }
+}
+```
+
 The above scrips will lint the js files while pushing to git. It will terminate the process if there are any errors, otherwise, the changes will be pushed.
 
 ### With Errors
@@ -90,7 +131,7 @@ The above scrips will lint the js files while pushing to git. It will terminate 
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/theenadayalank/lint-prepush/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/theenadayalank/lint-prepush/tags).
 
 ## Authors
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ if (process.stdout.isTTY) {
 
 (function() {
   const Listr = require("listr");
-  const chalk = require("chalk");
   const debug = require("debug")("lint-prepush:index");
   const os = require('os');
   const Cache = require("file-system-cache").default;
@@ -16,98 +15,81 @@ if (process.stdout.isTTY) {
     ns: process.cwd() //A grouping namespace for items.
   });
 
-  const { log } = console;
-
   const { loadConfig, execChildProcess } = require("./utils/common");
   const resolveMainTask = require("./utils/resolveMainTask");
   const fetchGitDiff = require("./utils/fetchGitDiff");
+  const { theme } = require('./utils/theme');
 
-  let theme = {
-    success: "green",
-    error: "red",
-    warning: "orange"
-  };
+  theme.then(({ success, error, warning }) => {
+    loadConfig()
+      .then(({ config = {} } = {}) => {
+        let {
+          base : baseBranch = 'master',
+          tasks = {},
+        } = config;
 
-  loadConfig()
-    .then(({ config = {} } = {}) => {
+        debug('Base Branch:' + baseBranch);
 
-      let {
-        base : baseBranch = 'master',
-        tasks = {},
-        theme: userTheme = {},
-      } = config;
+        // Skip linter for base branch
+        let getCurrentBranchCommand = 'git rev-parse --abbrev-ref HEAD';
+        execChildProcess({ command: getCurrentBranchCommand })
+          .then(currentBranch => {
 
-      theme = Object.assign(theme, userTheme);
+            debug('Current Branch:' + currentBranch);
 
-      const success = chalk.keyword(theme.success);
-      const error = chalk.keyword(theme.error);
-      const warning = chalk.keyword(theme.warning);
+            if(currentBranch === baseBranch) {
+              warning("\nNOTE: Skipping checks since you are in the base branch\n");
+              return;
+            }
 
-      debug('Base Branch:' + baseBranch);
+            execChildProcess({ command: 'git rev-parse HEAD' })
+              .then((commitHash = '') => {
+                debug('Curret Commit Hash:' + commitHash);
 
-      // Skip linter for base branch
-      let getCurrentBranchCommand = 'git rev-parse --abbrev-ref HEAD';
-      execChildProcess({ command: getCurrentBranchCommand })
-        .then(currentBranch => {
+                let cachedCommitHash = cache.getSync("linted-hash") || "";
+                debug('Cached Commit Hash:' + cachedCommitHash);
 
-          debug('Current Branch:' + currentBranch);
+                if(commitHash === cachedCommitHash) {
+                  warning("\nNOTE: Skipping checks since the commit(s) have been linted already.\n");
+                  return;
+                }
 
-          if(currentBranch === baseBranch) {
-            log(warning("\nNOTE: Skipping checks since you are in the base branch\n"));
-            return;
-          }
-
-          execChildProcess({ command: 'git rev-parse HEAD' })
-            .then((commitHash = '') => {
-              debug('Curret Commit Hash:' + commitHash);
-
-              let cachedCommitHash = cache.getSync("linted-hash") || "";
-              debug('Cached Commit Hash:' + cachedCommitHash);
-
-              if(commitHash === cachedCommitHash) {
-                log(warning("\nNOTE: Skipping checks since the commit(s) have been linted already.\n"));
-                return;
-              }
-
-              // Fetching committed git files
-              fetchGitDiff( baseBranch ).then((committedGitFiles = []) => {
-                debug(committedGitFiles);
-                new Listr(resolveMainTask({ tasks, committedGitFiles }), {
-                  exitOnError: false,
-                  concurrent: true,
-                  collapse: false
-                })
-                  .run()
-                  .then(() => {
-                    cache.setSync("linted-hash", commitHash);
-                    debug('Cached Current Commit Hash');
-                    log(success("\nVoila! 🎉  Code is ready to be Shipped.\n"));
+                // Fetching committed git files
+                fetchGitDiff( baseBranch ).then((committedGitFiles = []) => {
+                  debug(committedGitFiles);
+                  new Listr(resolveMainTask({ tasks, committedGitFiles }), {
+                    exitOnError: false,
+                    concurrent: true,
+                    collapse: false
                   })
-                  .catch(({ errors }) => {
-                    process.exitCode = 1;
-                    errors.forEach(err => {
-                      console.error(err.customErrorMessage);
+                    .run()
+                    .then(() => {
+                      cache.setSync("linted-hash", commitHash);
+                      debug('Cached Current Commit Hash');
+                      success("\nVoila! 🎉  Code is ready to be Shipped.\n");
+                    })
+                    .catch(({ errors }) => {
+                      process.exitCode = 1;
+                      errors.forEach(err => {
+                        console.error(err.customErrorMessage);
+                      });
                     });
-                  });
-              })
-              .catch((message = '') => {
-                process.exitCode = 1;
-                log(warning(message));
+                })
+                .catch((message = '') => {
+                  process.exitCode = 1;
+                  warning(message);
+                });
               });
-            });
-        })
-        .catch(() => {
-          log(error('\nCould not get the current Branch.\n'));
-          process.exitCode = 1;
-          return;
-        });
-    })
-
-    .catch(() => {
-      const error = chalk.keyword(theme.error);
-
-      process.exitCode = 1;
-
-      log(error("\nLoading Configuration⚙️ Failed!😑\n"));
-    });
+          })
+          .catch(() => {
+            error('\nCould not get the current Branch.\n');
+            process.exitCode = 1;
+            return;
+          });
+      })
+      .catch(() => {
+        process.exitCode = 1;
+        error("\nLoading Configuration⚙️ Failed!😑\n");
+      });
+  });
 })();

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ if (process.stdout.isTTY) {
 
   const success = chalk.keyword("green");
   const error = chalk.keyword("red");
-  const warning = chalk.keyword("yellow");
+  const warning = chalk.keyword("magenta");
 
   const { log } = console;
 

--- a/index.js
+++ b/index.js
@@ -16,20 +16,33 @@ if (process.stdout.isTTY) {
     ns: process.cwd() //A grouping namespace for items.
   });
 
-  const success = chalk.keyword("green");
-  const error = chalk.keyword("red");
-  const warning = chalk.keyword("magenta");
-
   const { log } = console;
 
   const { loadConfig, execChildProcess } = require("./utils/common");
   const resolveMainTask = require("./utils/resolveMainTask");
   const fetchGitDiff = require("./utils/fetchGitDiff");
 
+  let theme = {
+    success: "green",
+    error: "red",
+    warning: "orange"
+  };
+
   loadConfig()
     .then(({ config = {} } = {}) => {
 
-      let { base : baseBranch = 'master', tasks = {} } = config;
+      let {
+        base : baseBranch = 'master',
+        tasks = {},
+        theme: userTheme = {},
+      } = config;
+
+      theme = Object.assign(theme, userTheme);
+
+      const success = chalk.keyword(theme.success);
+      const error = chalk.keyword(theme.error);
+      const warning = chalk.keyword(theme.warning);
+
       debug('Base Branch:' + baseBranch);
 
       // Skip linter for base branch
@@ -91,7 +104,10 @@ if (process.stdout.isTTY) {
     })
 
     .catch(() => {
+      const error = chalk.keyword(theme.error);
+
       process.exitCode = 1;
+
       log(error("\nLoading Configuration⚙️ Failed!😑\n"));
     });
 })();

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,0 +1,32 @@
+const chalk = require("chalk");
+
+const { loadConfig } = require('./common');
+
+const message = (color, output) => console.log(chalk.keyword(color)(...output));
+
+const defaultTheme = {
+  success: (...output) => message('green', output),
+  warning: (...output) => message('orange', output),
+  error: (...output) => message('red', output),
+};
+
+// extend our default theme with any user-supplied theme colors
+const theme = loadConfig()
+  .then(({ config = {} }) => {
+    const { theme: userTheme = {} } = config;
+
+    return Object.keys(userTheme).reduce((themeObject, type) => {
+      themeObject[type] = (...output) => message(userTheme[type], output);
+
+      return themeObject;
+    }, defaultTheme);
+  })
+  .catch(() => {
+    process.exitCode = 1;
+    defaultTheme.error("\nLoading Configuration⚙️ Failed!😑\n");
+  });
+
+module.exports = {
+  theme,
+  defaultTheme,
+};


### PR DESCRIPTION
I adjusted the `warning` color to be `orange`, but also thought that since we can't really be sure what will work for all users, we could open it up to allow the user to theme the `success`, `error`, and `warning` output via any available `chalk` keyword.

If that's too much, I'd be happy to dial it back to just a change in the `warning` color.

Closes #19 