### PR TITLE
revert: use remote/currentBranch for diff if it has already been pus…

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -1,13 +1,12 @@
 const chai = require('chai'); // eslint-disable-line node/no-unpublished-require
 const { expect } = chai;
-const { execChildProcess } = require('../utils/common');
+const { execSyncProcess } = require('../utils/common');
 
 describe('Test commmon util functions', () => {
-  describe('Assert execChildProcess() function', () => {
-    it('should return Hello World', () => {
-      return execChildProcess({ command : "echo 'Hello World!' " }).then( (result = '') => {
-        expect(result).to.equal('Hello World!');
-      });
+  describe('Assert execSyncProcess() function', () => {
+    it('should return Foo Bar', () => {
+      let result = execSyncProcess("echo 'Foo Bar!' ");
+      expect(result).to.equal('Foo Bar!');
     });
   });
 });

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,5 +1,5 @@
 const cosmiconfig = require("cosmiconfig");
-const { exec } = require("child_process");
+const { execSync } = require("child_process");
 
 const userConfig = (cosmiconfig("lint-prepush", {
   searchPlaces: [
@@ -13,21 +13,15 @@ const userConfig = (cosmiconfig("lint-prepush", {
   ]
 }).searchSync() || {}).config;
 
-function execChildProcess({ command = "" } = {}) {
-  return new Promise( (resolve, reject) => {
-    exec(command , (err, stdout, stderr) => {
-      if (err) {
-        reject(stderr);
-      }
-      let result = (stdout.toString() || "").split('\n');
-      result = result.slice(0,-1);
-      result = result.join('\n');
-      resolve(result);
-    });
-  });
+function execSyncProcess(command = '') {
+  let result = execSync(command).toString() || '';
+  result = result.split('\n');
+  result = result.slice(0,-1);
+  result = result.join('\n');
+  return result;
 }
 
 module.exports = {
   userConfig,
-  execChildProcess
+  execSyncProcess
 };

--- a/utils/fetchGitDiff.js
+++ b/utils/fetchGitDiff.js
@@ -1,18 +1,10 @@
-const { execChildProcess } = require("./common");
+const { execSyncProcess } = require("./common");
 
 module.exports = function fetchGitDiff( baseBranch = "master" ) {
-
   // git command to pull out the changed file names between current branch and base branch (Excluded delelted files which cannot be fetched now)
   let command = `git diff --relative --name-only --diff-filter=d ${baseBranch}...HEAD`;
 
-  return new Promise( (resolve, reject) => {
-    return execChildProcess({ command })
-      .then((result = '') => {
-        let fileList = result.split('\n');
-        resolve(fileList);
-      })
-      .catch((err) => {
-        reject(`\n Fetching committed file list process has been stopped with the following error: \n ${err}`);
-      });
-  });
+  let committedGitFiles = execSyncProcess(command) || "";
+  committedGitFiles = committedGitFiles.split('\n');
+  return committedGitFiles;
 };


### PR DESCRIPTION
- [REVERT] Use remote/current_branch for diff if it has already been pushed to remote
- Remove Async functions to make the code less verbose (fixes: #36 )