### PR TITLE
Fix matchBase breaking glob patterns if always on

### DIFF
--- a/utils/resolveMainTask.js
+++ b/utils/resolveMainTask.js
@@ -27,7 +27,7 @@ function constructTaskList({ tasks = {}, committedGitFiles = [] } = {}) {
     let fileList = [];
     let commandList = tasks[fileFormat];
     fileList = micromatch(committedGitFiles, [fileFormat], {
-      matchBase: true,
+      matchBase: !fileFormat.includes('/'),
       dot: true
     }).map(file => path.resolve(cwd, file));
     return { fileFormat, commandList, fileList };

--- a/utils/resolveMainTask.js
+++ b/utils/resolveMainTask.js
@@ -27,6 +27,7 @@ function constructTaskList({ tasks = {}, committedGitFiles = [] } = {}) {
     let fileList = [];
     let commandList = tasks[fileFormat];
     fileList = micromatch(committedGitFiles, [fileFormat], {
+      // Glob patterns break if matchBase is true, disable if fileFormat looks like path
       matchBase: !fileFormat.includes('/'),
       dot: true
     }).map(file => path.resolve(cwd, file));


### PR DESCRIPTION
The following is with a console statement included in `resolveMainTask` without the fix:

![lint-prepush-broken](https://user-images.githubusercontent.com/6438760/78357187-48d80800-75b1-11ea-921b-3deae918b619.png)

This is after adding the fix:

![lint-prepush-fixed](https://user-images.githubusercontent.com/6438760/78357215-52fa0680-75b1-11ea-99de-9589570c7c6b.png)

For globas such as `*.md`, matchBase is enabled and they match correctly even in subfolders.

This fix is based on lint-staged implementation
https://github.com/okonet/lint-staged/blob/072924fce037c726112c00a6207afa92e238a267/lib/generateTasks.js#L49