### PR TITLE
Check for diffBranch existence before fetch files

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ if (process.stdout.isTTY) {
 
   let isdiffBranchExisted = false;
   try {
-    isdiffBranchExisted = checkForBranchExistence(diffBranch);
+    isdiffBranchExisted = checkForBranchExistence(baseBranch,remote);
     debug('Check whether branch is existed: ', diffBranch);
   } catch (err) {
     process.exitCode = 1;

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ if (process.stdout.isTTY) {
 
   let committedGitFiles = [];
   if (isdiffBranchExisted) {
+    log(success('Great, we find the ' + diffBranch + ' branch.'));
     try {
       committedGitFiles = fetchGitDiff(diffBranch);
       debug('Committed GIT files: ', committedGitFiles);
@@ -119,6 +120,8 @@ if (process.stdout.isTTY) {
   }
   // if diffBranch is not existed,get all tracked files on currentBranch to lint
   else {
+    log(warning('Sorry, we cannot find the ' + diffBranch + ' branch.'));
+    log(warning('So,we use ' + currentBranch + 'branch instead'));
     try {
       committedGitFiles = getAllTrackedFiles(currentBranch);
       debug('Tracked files: ', committedGitFiles);

--- a/utils/checkForBranchExistence.js
+++ b/utils/checkForBranchExistence.js
@@ -1,0 +1,12 @@
+const { execSyncProcess } = require('./common');
+
+module.exports = function checkForBranchExistence(branch = 'master', remote = '') {
+  // check whether branch exists local
+  let command = `git branch --list ${branch}`;
+  if (remote) {
+    // check whether branch exists in remote repo
+    command = `git ls-remote --heads ${remote} ${branch}`;
+  }
+  let isExisted = execSyncProcess(command) || '';
+  return !!isExisted;
+};

--- a/utils/getAllTrackedFiles.js
+++ b/utils/getAllTrackedFiles.js
@@ -1,0 +1,9 @@
+const { execSyncProcess } = require('./common');
+
+module.exports = function getAllTrackedFiles(branch = 'master') {
+  let command = `git ls-tree -r ${branch} --name-only`;
+
+  let committedGitFiles = execSyncProcess(command) || '';
+  committedGitFiles = committedGitFiles.split('\n');
+  return committedGitFiles;
+};


### PR DESCRIPTION
This PR introduces a check to see if the diffBranch is existed. If not, lint all tracked files instead of fetch from origin branch or baseBranch.

Closes #114