### PR TITLE
Adds verbose config option to print output even if tasks succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lint-prepush    
+# lint-prepush
 [![npm version](https://badge.fury.io/js/lint-prepush.svg)](https://www.npmjs.com/package/lint-prepush)
 [![npm downloads](https://img.shields.io/npm/dt/lint-prepush.svg)](https://www.npmtrends.com/lint-prepush)
 [![GitHub license](https://img.shields.io/github/license/theenadayalank/lint-prepush.svg)](https://github.com/theenadayalank/lint-prepush/blob/master/LICENSE)
@@ -13,7 +13,7 @@ This package will run linters on your project for the committed files in your br
 
 ### Prerequisites🔭
 
-* This package requires Node.js `>=8`. 
+* This package requires Node.js `>=8`.
 * A package to manage git hooks.
 
 ### Installing
@@ -34,7 +34,7 @@ yarn add --dev husky lint-prepush
 
 Configure the following scripts in package.json to lint your committed files 🔧. You can also follow any of the  [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) methods to configure lint-prepush.
 
-* Here [Husky](https://github.com/typicode/husky) is used for managing git hooks. 
+* Here [Husky](https://github.com/typicode/husky) is used for managing git hooks.
 
 ```diff
 {
@@ -64,7 +64,7 @@ The above scrips will lint the js files while pushing to git. It will terminate 
 
 ### Concurrent Tasks
 
-Tasks for a file group will by default run in linear order (eg. `"*.js": [ "jest", "eslint"]` will run jest first, then after it's done run eslint). 
+Tasks for a file group will by default run in linear order (eg. `"*.js": [ "jest", "eslint"]` will run jest first, then after it's done run eslint).
 If you'd like to run tasks for a file group concurrently instead (eg. jest and eslint in parallel), use the `concurrent` property like so:
 
 ```diff
@@ -76,6 +76,19 @@ If you'd like to run tasks for a file group concurrently instead (eg. jest and e
 +      }
 +    }
 +  }
+}
+```
+
+### Verbose
+
+By default when the tasks succeed, there is no output printed to the console. Sometimes you might need to show linter rules configured for `warn` which should be displayed even if the tasks succeed. In order to achieve this, you can pass the config `verbose: true` so that the task output is printed to the console when the tasks succeed.
+
+```
+"lint-prepush": {
+  "verbose": true,
+  "tasks": {
+    ...
+  }
 }
 ```
 
@@ -93,7 +106,7 @@ If you'd like to run tasks for a file group concurrently instead (eg. jest and e
 
 ## Versioning
 
-This package use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/theenadayalank/lint-prepush/tags). 
+This package use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/theenadayalank/lint-prepush/tags).
 
 ## Authors
 

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ if (process.stdout.isTTY) {
   .then(() => {
     cache.setSync("linted-hash", commitHash);
     debug('Cached Current Commit Hash');
-    if (options.verbose) {
+    if (options.verbose && options.output.length) {
       log(success('\nAll tasks completed successfully. Printing tasks output.\n'));
       for (const line of options.output) {
         log(line);

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ if (process.stdout.isTTY) {
 
   let {
     base : baseBranch = 'master',
-    tasks = {}
+    tasks = {},
+    verbose = false
   } = userConfig || {};
 
   debug('Base Branch: ' + baseBranch);
@@ -133,7 +134,12 @@ if (process.stdout.isTTY) {
     }
   }
 
-  new Listr(resolveMainTask({ tasks, committedGitFiles }), {
+  const options = {
+    verbose,
+    output: []
+  };
+
+  new Listr(resolveMainTask({ tasks, committedGitFiles, options }), {
     exitOnError: false,
     concurrent: true,
     collapse: false
@@ -142,6 +148,12 @@ if (process.stdout.isTTY) {
   .then(() => {
     cache.setSync("linted-hash", commitHash);
     debug('Cached Current Commit Hash');
+    if (options.verbose) {
+      log(success('\nAll tasks completed successfully. Printing tasks output.\n'));
+      for (const line of options.output) {
+        log(line);
+      }
+    }
     log(success("\nVoila! 🎉  Code is ready to be Shipped.\n"));
   })
   .catch( ({ errors }) => {

--- a/utils/execTask.js
+++ b/utils/execTask.js
@@ -8,7 +8,7 @@ function getFormattedTime(end) {
   return Math.round((end[0] * 1000) + (end[1] / 1000000));
 }
 
-module.exports = function execTask({ command, fileList, task }) {
+module.exports = function execTask({ command, fileList, task, options = {} }) {
   let { executor, args } = resolveLinterPackage({ command, fileList });
   let startTime = process.hrtime();
 
@@ -19,6 +19,9 @@ module.exports = function execTask({ command, fileList, task }) {
       task.title = `${task.title} ${chalk.grey(elapsedTime)}`;
 
       if (!result.failed) {
+        if (options.verbose) {
+          processOutput(command, result, options);
+        }
         return `Passed ${command}`;
       }
 
@@ -46,4 +49,15 @@ function constructErrorObject(command, error, output) {
     ${error}
   `;
   return e;
+}
+
+function processOutput(command, { stderr, stdout }, options) {
+  const hasOutput = !!stderr || !!stdout;
+  if (hasOutput) {
+    const output = []
+      .concat(`\n${symbols.info} Task: ${command}\n`)
+      .concat(stderr ? stderr : [])
+      .concat(stdout ? stdout : []);
+    options.output.push(output.join('\n'));
+  }
 }

--- a/utils/resolveLintTask.js
+++ b/utils/resolveLintTask.js
@@ -1,13 +1,14 @@
 const execTask = require("./execTask");
 
-module.exports = function resolveLintTask(commandList, fileList) {
+module.exports = function resolveLintTask(commandList, fileList, options) {
   return commandList.map(command => ({
     title: command,
     task: (ctx, task) => execTask({
       command,
       fileList,
       ctx,
-      task
+      task,
+      options
     })()
   }));
 };

--- a/utils/resolveMainTask.js
+++ b/utils/resolveMainTask.js
@@ -5,11 +5,11 @@ const micromatch = require("micromatch");
 const cwd = process.cwd();
 const resolveLintTask = require("./resolveLintTask");
 
-module.exports = function resolveMainTask( options = {} ) {
-  return constructTaskList(options).map(task => ({
+module.exports = function resolveMainTask( config = {} ) {
+  return constructTaskList(config).map(task => ({
     title: `Linting ${task.fileFormat} files`,
     task: () =>
-      new Listr(resolveLintTask(task.commandList.concurrent || task.commandList, task.fileList), {
+      new Listr(resolveLintTask(task.commandList.concurrent || task.commandList, task.fileList, config.options), {
         exitOnError: true,
         concurrent: Array.isArray(task.commandList.concurrent)
       }),


### PR DESCRIPTION
When you have configured a lint rule to show warnings like,
```
'no-partial': 'warn'
```
the output is suppressed because we do not show any output if all the tasks run successfully. I have introduced a verbose flag which by default will be `false`. When turned on, this will store the output to an array and will be logged to the console when all the tasks are successfully completed. This helps in seeing the lint rules which are configured as `warn` in the terminal. 

<img width="945" alt="output" src="https://user-images.githubusercontent.com/19588386/85359284-72ab2600-b533-11ea-9200-2fff4f7231fe.png">

[Related Issue](https://github.com/theenadayalank/lint-prepush/issues/134)