### PR TITLE
Detect the upstream branch name when base is not specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,10 +69,24 @@ if (process.stdout.isTTY) {
   }
 
   let {
-    base : baseBranch = 'master',
+    base : baseBranch,
     tasks = {},
     verbose = false
   } = userConfig || {};
+
+  let isdiffBranchExisted = false;
+
+  if (!baseBranch) {
+    debug('Base not specified, checking for upstream ref');
+    try {
+      baseBranch = execSyncProcess('git rev-parse --abbrev-ref $branch@{upstream}');
+      isdiffBranchExisted = true;
+      debug('Upstream branch name', baseBranch);
+    } catch(error) {
+      // fall back to original behavior of hard-coding the name master
+      baseBranch = 'master';
+    }
+  }
 
   debug('Base Branch: ' + baseBranch);
 
@@ -95,10 +109,9 @@ if (process.stdout.isTTY) {
     debug('Branch to Diff: ', diffBranch);
   }
 
-  let isdiffBranchExisted = false;
   try {
-    isdiffBranchExisted = checkForBranchExistence(baseBranch,remote);
-    debug('Check whether branch is existed: ', diffBranch);
+    isdiffBranchExisted = isdiffBranchExisted ? isdiffBranchExisted : checkForBranchExistence(baseBranch,remote);
+    debug('Check whether branch exists: ', diffBranch);
   } catch (err) {
     process.exitCode = 1;
     log(warning('\nCheck for diffBranch existence process has been stopped with the following error\n'));


### PR DESCRIPTION
Currently the `lint-prepush` command assumes `master` as a base branch in the project. 

While the configuration does allow this to be explicitly overridden we can potentially provide a default behavior that works even when a project doesn't use `master` as a base branch.

### Changes

When the `base` branch is _not explicitly specified_, instead of defaulting to `master`, `git rev-parse` can be used to determine the named git ref for the remote branch being pushed to.

For example, I'm on a local branch named `fix/hard-coded-master`, and it is set to use `origin/fix/hard-coded-master` as the upstream branch.

```
git branch --set-upstream-to=origin/fix/hard-coded-master
```

Using `git rev-parse` when can see what the current branch's upsream ref is:

```
git rev-parse --abbrev-ref $branch@{upstream}
origin/fix/hard-coded-master
```

Using this information, when the `base` branch is not explicitly specified **and** the local branch has an upstream branch, we can now use these two refs with `git diff` to get the list of relevant files.

Here's the command as `utils/fetchGitDiff.js` would run it:

```
git diff `git rev-parse --abbrev-ref $branch@{upstream}`...HEAD
index.js
```

### How To Test

Make sure the local branch has an upstream branch and the `base` is not specified in `package.json`:

```
git branch --set-upstream-to=origin/fix/hard-coded-master
Branch 'fix/hard-coded-master' set up to track remote branch 'fix/hard-coded-master' from 'origin'.

cat package.json| jq '.["lint-prepush"].base'
null
```

Clear out the `.lint-prepush` cache:

```
rm -r ~/.lint-prepush
```

Reset the remote branch to remove the local branch's commits if they've already been pushed:

```
git push --force origin master:fix/hard-coded-master
```

Run `git push` with `DEBUG=*`

```
DEBUG=* git push 
  // snip
  lint-prepush:index Base not specified, checking for upstream ref +1ms
  lint-prepush:index Upstream branch name origin/fix/hard-coded-master +7ms
  // stip
  lint-prepush:index Committed GIT files:  [ 'index.js' ] +9ms
  ✔ Linting *.js files
    ✔ node_modules/.bin/eslint (401ms)
  lint-prepush:index Cached Current Commit Hash +410ms

Voila! 🎉  Code is ready to be Shipped.

```




